### PR TITLE
dunder version correction, pre-commit and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,17 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+*.mpy
+.idea
 __pycache__
 _build
 *.pyc
 .env
+.python-version
+build*/
 bundles
+*.DS_Store
+.eggs
+dist
+**/*.egg-info
+.vscode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,11 @@
 
 repos:
 -   repo: https://github.com/python/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: latest
+    rev: v0.12.1
     hooks:
     - id: reuse
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/adafruit_rplidar.py
+++ b/adafruit_rplidar.py
@@ -34,7 +34,7 @@ import warnings
 # pylint:disable=invalid-name,undefined-variable,global-variable-not-assigned
 # pylint:disable=too-many-arguments,raise-missing-from
 
-__version__ = "0.0.1-auto.0"
+__version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RPLIDAR.git"
 
 SYNC_BYTE = b"\xA5"


### PR DESCRIPTION
- The dunder version is corrected see related: https://github.com/adafruit/circup/issues/79
- Updated .gitignore to match cookiecutter since pre-commit was failing on files which should be ignored
- Updated pre-commit hook versions to match cookiecutter since pre-commit was complaining.